### PR TITLE
feat(plugin): 新增插件版本查询机制

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luo9_bot"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 edition = "2024"
 authors = ["luoy-oss <2557657882@qq.com>"]
 description = "洛玖机器人"
@@ -13,7 +13,7 @@ plugins = []  # 插件系统支持
 default = ["napcat"]
 
 [dependencies]
-luo9_sdk = "0.5.1"
+luo9_sdk = "0.5.2"
 # luo9_sdk = { path = "H:\\github\\luo9_bot\\sdk\\rust" }
 
 # 异步运行时

--- a/src/plugin/bus.rs
+++ b/src/plugin/bus.rs
@@ -13,6 +13,8 @@ pub const TOPIC_NOTICE: &str = "luo9_notice";
 pub const TOPIC_TASK_MISO: &str = "luo9_task_miso";
 pub const TOPIC_TASK: &str = "luo9_task";
 pub const TOPIC_SEND: &str = "luo9_send";
+pub const TOPIC_VERSION: &str = "luo9_version";
+pub const TOPIC_VERSION_REPLY: &str = "luo9_version_reply";
 
 pub fn publish_data(data: &PluginData) {
     let topic_name = match data {

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -35,6 +35,23 @@ impl PluginManager {
         &self.plugin_infos
     }
 
+    /// 按名称更新插件版本
+    pub fn update_plugin_version(&mut self, name: &str, version: &str) {
+        if let Some(info) = self.plugin_infos.iter_mut().find(|p| p.name == name) {
+            info.version = version.to_string();
+            info!("插件 #{} ({}) 版本更新为: {}", info.id, info.name, version);
+        }
+    }
+
+    /// 将所有空版本的插件标记为 Unknown
+    pub fn mark_unknown_versions(&mut self) {
+        for info in &mut self.plugin_infos {
+            if info.version.is_empty() {
+                info.version = "Unknown".to_string();
+            }
+        }
+    }
+
     /// 获取统计信息
     pub fn get_stats(&self) -> String {
         format!("插件统计: 总数={}", self.plugin_infos.len())

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -5,6 +5,7 @@ pub mod loader;
 pub mod data;
 pub mod task;
 pub mod sender;
+pub mod version;
 
 // 重新导出常用类型和函数
 pub use bus::publish_data;
@@ -45,6 +46,9 @@ pub async fn initialize(plugins_dir: &str) -> Result<(), Box<dyn std::error::Err
 
     // 注册插件信息到全局管理器
     init_global_manager(infos).await;
+
+    // 查询插件版本（5秒超时）
+    version::query_versions(std::time::Duration::from_secs(5)).await;
 
     info!("插件系统初始化完成");
     Ok(())

--- a/src/plugin/version.rs
+++ b/src/plugin/version.rs
@@ -1,0 +1,67 @@
+// src/plugin/version.rs
+// 插件版本查询：宿主启动后广播查询，收集各插件版本信息
+
+use std::time::{Duration, Instant};
+use tracing::{debug, error, info, warn};
+
+use super::bus;
+use super::manager::GLOBAL_PLUGIN_MANAGER;
+
+/// 查询所有插件版本，带超时
+///
+/// 必须在插件加载完成、插件线程已启动之后调用。
+/// 内部流程：
+/// 1. 订阅 luo9_version_reply（接收插件响应）
+/// 2. 发布 query 到 luo9_version（触发插件响应）
+/// 3. 在超时内循环 pop 响应消息
+/// 4. 超时后将未响应的插件标记为 "Unknown"
+pub async fn query_versions(timeout: Duration) {
+    // 1. 先订阅响应 topic，确保不会漏掉任何响应
+    let reply_sub = bus::Bus::topic(bus::TOPIC_VERSION_REPLY)
+        .subscribe()
+        .unwrap_or_else(|e| panic!("订阅 {} topic 失败: {:?}", bus::TOPIC_VERSION_REPLY, e));
+    info!("[version] 已订阅版本响应 topic, sub_id={}", reply_sub);
+
+    // 2. 发布查询
+    let query = r#"{"action":"query"}"#;
+    if let Err(e) = bus::Bus::topic(bus::TOPIC_VERSION).publish(query) {
+        error!("[version] 发布版本查询失败: {:?}", e);
+        return;
+    }
+    info!("[version] 已发布版本查询，等待插件响应...");
+
+    // 3. 收集响应（带超时）
+    let deadline = Instant::now() + timeout;
+    let mut responded = 0u32;
+
+    while Instant::now() < deadline {
+        if let Some(json) = bus::Bus::topic(bus::TOPIC_VERSION_REPLY).pop(reply_sub) {
+            debug!("[version] 收到响应: {}", json);
+            match serde_json::from_str::<serde_json::Value>(&json) {
+                Ok(resp) => {
+                    let action = resp["action"].as_str().unwrap_or("");
+                    if action == "response" {
+                        let name = resp["name"].as_str().unwrap_or("").to_string();
+                        let version = resp["version"].as_str().unwrap_or("Unknown").to_string();
+                        if !name.is_empty() {
+                            let mut manager = GLOBAL_PLUGIN_MANAGER.lock().await;
+                            manager.update_plugin_version(&name, &version);
+                            responded += 1;
+                        }
+                    }
+                }
+                Err(e) => warn!("[version] 解析响应失败: {}", e),
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // 4. 标记未响应的插件
+    let total = {
+        let mut manager = GLOBAL_PLUGIN_MANAGER.lock().await;
+        manager.mark_unknown_versions();
+        manager.get_all_plugins().len()
+    };
+
+    info!("[version] 版本查询完成: {}/{} 个插件已响应", responded, total);
+}


### PR DESCRIPTION
- 在插件系统初始化后自动广播版本查询请求
- 添加版本管理功能，支持更新插件版本信息
- 未响应查询的插件版本将被标记为 Unknown
- 升级 luo9_sdk 依赖至 0.5.2 版本
- 更新项目版本至 0.1.0-beta.3