### PR TITLE
ci(github-actions): 为发布工作流指定应用所有者

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: luo9-bot
           repositories: registry
 
       - name: 读取 Cargo.toml 信息


### PR DESCRIPTION
添加 owner 字段以明确指定 GitHub App 的所有者，确保工作流能正确访问目标仓库。