### PR TITLE
feat(webui): 在标题中显示Bot和WebUI版本号

### DIFF
--- a/src/webui.rs
+++ b/src/webui.rs
@@ -41,6 +41,9 @@ const GITHUB_RELEASE_MIRRORS: &[&str] = &[
 /// HTTP 请求超时时间
 const HTTP_TIMEOUT_SECS: u64 = 10;
 
+/// WebUI 版本号
+const WEBUI_VERSION: &str = "1.0.0";
+
 /// 镜像健康检查测试 URL（用于检测连通性）
 const MIRROR_TEST_URL: &str = "https://raw.githubusercontent.com/luo9-bot/registry/main/registry.json";
 
@@ -133,6 +136,8 @@ struct StatusResponse {
     plugin_count: usize,
     plugins: Vec<PluginInfo>,
     plugin_dir: String,
+    bot_version: String,
+    webui_version: String,
 }
 
 #[derive(Deserialize)]
@@ -549,6 +554,8 @@ async fn api_status(State(state): State<Arc<WebuiState>>) -> impl IntoResponse {
         plugin_count: plugins.len(),
         plugins,
         plugin_dir: state.plugin_dir.clone(),
+        bot_version: env!("CARGO_PKG_VERSION").to_string(),
+        webui_version: WEBUI_VERSION.to_string(),
     };
     Json(resp)
 }

--- a/src/webui/app.js
+++ b/src/webui/app.js
@@ -116,6 +116,12 @@
       document.getElementById('stat-uptime').textContent = formatUptime(data.uptime_secs);
       document.getElementById('stat-plugins').textContent = data.plugin_count;
       document.getElementById('stat-dir').textContent = data.plugin_dir;
+      const verEl = document.getElementById('bot-version');
+      if (verEl) {
+        const bot = data.bot_version || '?';
+        const webui = data.webui_version || '?';
+        verEl.textContent = `Bot v${bot} · WebUI v${webui}`;
+      }
     } catch (e) {
       console.error('获取状态失败:', e);
     }

--- a/src/webui/index.html
+++ b/src/webui/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Luo9 Bot 控制台</title>
+  <title>来看洛玖啦</title>
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
 
 <!-- ═══ Header ═══ -->
 <header class="header">
-  <h1>🐾 Luo9 Bot 控制台</h1>
+  <h1>🐾 来看洛玖啦 <span class="header-version" id="bot-version"></span></h1>
   <div class="header-status">
     <span class="status-dot"></span>
     <span id="header-status-text">运行中</span>

--- a/src/webui/style.css
+++ b/src/webui/style.css
@@ -60,6 +60,17 @@ body {
   text-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
 
+.header-version {
+  font-size: 0.55em;
+  font-weight: 400;
+  opacity: 0.75;
+  background: rgba(255,255,255,0.15);
+  padding: 2px 8px;
+  border-radius: 10px;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
 .header-status {
   display: flex;
   align-items: center;


### PR DESCRIPTION
- 新增版本号显示样式，在标题右侧添加版本标签
- 修改页面标题为"来看洛玖啦"
- 后端API返回bot_version和webui_version字段
- 前端JavaScript动态渲染版本信息到标题中